### PR TITLE
Added comment explaining how to start mongodb if it refuses to

### DIFF
--- a/attention/attention_interface.py
+++ b/attention/attention_interface.py
@@ -10,6 +10,10 @@ __author__ = 'Cosmo Harrigan'
 from configuration import *
 
 # MongoDB needs to be started with 'sudo service mongod start'
+# If MongoDB refuses to start, e.g. after a recent crash, check the log at
+# /var/log/mongodb/mongodb.log. This may be due to an old lock file which can
+# be easily removed with "rm /var/lib/mongodb/mongod.lock"
+
 # Create a MongoDB connection
 client = pymongo.MongoClient(MONGODB_CONNECTION_STRING)
 mongo = client[MONGODB_DATABASE]


### PR DESCRIPTION
@cosmoharrigan, in the future when attention allocation is used more often, I think it would be good if some modules that just require the use of a few methods of the `attention_interface` wouldn't need to start mongodb beforehand if they don't use it. At the moment, I added another comment explaining how to start mongodb. I think it would be good, though, if creating the mongodb connection would be put into its own method so a connection is instantiated only when required. What do you think, Cosmo?
