### PR TITLE
Slide show functionality

### DIFF
--- a/glimpse/index.html
+++ b/glimpse/index.html
@@ -31,7 +31,7 @@
     <title>Glimpse - Atomspace Viewer</title>
 </head>
 
-<body ng-controller="mainCtrl">
+<body ng-controller="mainCtrl" ng-init="slideMode=false">
 
 <!--Nav Bar-->
 <div class="navbar navbar-inverse navbar-fixed-top">
@@ -105,6 +105,11 @@
     </a>
     <a title="Edit" class="btn btn-sm btn-block" ng-class="[tool=='edit'?'btn-primary':'btn-default']" ng-click="tool='edit'">
         <i class="fa fa-pencil-square-o"></i>
+    </a>
+
+    <!--SLIDE MODE-->
+    <a title="SlideMode" class="btn btn-sm btn-block" ng-class="['btn-primary']" ng-click="$root.slideMode = $root.slideMode ? false : true">
+        <i class="fa fa-slideshare"></i>
     </a>
 
     <a title="Link" class="btn btn-sm btn-block" ng-class="[tool=='link'?'btn-primary':'btn-default']" ng-click="tool='link'">

--- a/glimpse/js/directives/connect.js
+++ b/glimpse/js/directives/connect.js
@@ -1,5 +1,5 @@
 angular.module('glimpse')
-    .directive('connect', function (AtomsFactory) {
+    .directive('connect', function ($rootScope, AtomsFactory) {
         var link = function (scope, element, attributes) {
             scope.state = "idle";
 
@@ -19,8 +19,7 @@ angular.module('glimpse')
                     setTimeout(function () {
                         scope.dialog.destroy();
                     }, 1500);
-                    setTimeout(updateAtoms, 10000);
-			                    
+                    setTimeout(updateAtoms, 5000);
                 };
 
                 var onFailure = function () {
@@ -32,8 +31,14 @@ angular.module('glimpse')
                         scope.$apply();
                     }, 2000);
                 };
-
-                AtomsFactory.updateAtoms(onSuccess, onFailure);
+                
+                if($rootScope.slideMode == true){
+                  console.log("SlideMode activated");
+                  AtomsFactory.sampleAtomsInAF(onSuccess, onFailure);
+                }
+                else{
+                  AtomsFactory.updateAtoms(onSuccess, onFailure);
+                }
             };
 
             scope.connect = function () {

--- a/glimpse/js/factories.js
+++ b/glimpse/js/factories.js
@@ -62,10 +62,47 @@ angular.module('glimpse')
 		
             });
         };
+        
+        atomsFactory.sampleAtomsInAF = function (successCB, failureCB) {
+          var sampleSize = 100;
+          var randIndex = function(sampleSize, sampleSpaceSize){ 
+            var arr = []
+            while(arr.length < sampleSize){
+              var randomnumber=Math.ceil(Math.random()* sampleSpaceSize)
+              var found=false;
+              for(var i=0;i<arr.length;i++){
+                if(arr[i]==randomnumber){found=true;break;}
+              }
+              if(!found)arr[arr.length]=randomnumber;
+            }
+          }
+          $http({
+            method: 'GET',
+            url: atomsFactory.server + 'api/v1.1/atoms?filterby=attentionalfocus'
+          }).then(
+            function (response){
+              var responseAtoms = response.data.result.atoms;
 
-	       
+              if (responseAtoms.length > sampleSize){
+                var randomAtoms = []
+                for(i in randIndex(sampleSize,responseAtoms.length)){
+                  randAtoms.push(responseAtoms[randIndex[i]]);
+                }
+                atomsFactory.atoms = randomAtoms;
+              }
+              else{
+                atomsFactory.atoms = responseAtoms;
+              }
+
+              atomsFactory.atomsCount = atomsFactory.atoms.length;
+              if (typeof successCB === "function") successCB();
+            },
+            function (error) {
+              if (typeof failureCB === "function") failureCB();
+            }
+          );
+        };
+
         return atomsFactory;
     })
-
-
-;
+  ;

--- a/glimpse/js/factories.js
+++ b/glimpse/js/factories.js
@@ -83,17 +83,21 @@ angular.module('glimpse')
           }).then(
             function (response){
               var responseAtoms = response.data.result.atoms;
-              if (responseAtoms.length > sampleSize){
+              console.log("ResponseAtomSize: "+responseAtoms.length);
+              /*if (responseAtoms.length > sampleSize){
                 var randomAtoms = []
                 for(i in randIndex(sampleSize,responseAtoms.length)){
                   var atom = responseAtoms[randIndex[i]];
                   randomAtoms.push(atom);
                 }
+                console.log("RandAtomSize: "+randomAtoms.length);
                 atomsFactory.atoms = randomAtoms;
               }
-              else{
+              else{*/
+
+                console.log("ResponseAtomSize: "+responseAtoms.length);
                 atomsFactory.atoms = responseAtoms;
-              }
+              //}
 
               atomsFactory.atomsCount = atomsFactory.atoms.length;
               if (typeof successCB === "function") successCB();

--- a/glimpse/js/factories.js
+++ b/glimpse/js/factories.js
@@ -75,18 +75,19 @@ angular.module('glimpse')
               }
               if(!found)arr[arr.length]=randomnumber;
             }
+            return arr;
           }
           $http({
             method: 'GET',
-            url: atomsFactory.server + 'api/v1.1/atoms?filterby=attentionalfocus'
+            url: atomsFactory.server + 'api/v1.1/atoms?filterby=attentionalfocus&includeOutgoing=true&includeIncoming=true'
           }).then(
             function (response){
               var responseAtoms = response.data.result.atoms;
-
               if (responseAtoms.length > sampleSize){
                 var randomAtoms = []
                 for(i in randIndex(sampleSize,responseAtoms.length)){
-                  randAtoms.push(responseAtoms[randIndex[i]]);
+                  var atom = responseAtoms[randIndex[i]];
+                  randomAtoms.push(atom);
                 }
                 atomsFactory.atoms = randomAtoms;
               }

--- a/glimpse/js/main.js
+++ b/glimpse/js/main.js
@@ -5,8 +5,6 @@ glimpse.controller("mainCtrl", function ($rootScope, $scope, $window, $timeout, 
   
   // If slide mode is enabled, refresh every 5 secs
   var slideModeReset = false;
-  glimpse.controller("mainCtrl", function ($rootScope, $scope, $window, $timeout, 
-      $interval, utils, AtomsFactory) {
     $rootScope.$watch('slideMode', function( ) {
       if( !slideModeReset){ slideModeReset = true;}
       else{

--- a/glimpse/js/main.js
+++ b/glimpse/js/main.js
@@ -1,8 +1,6 @@
 var glimpse = angular.module("glimpse", ["ngResource", "ngAnimate", "vAccordion"]);
 
-glimpse.controller("mainCtrl", function ($rootScope, $scope, $window, $timeout, utils, AtomsFactory) {
-
-  
+glimpse.controller("mainCtrl", function ($rootScope, $scope, $window, $timeout, $interval , utils, AtomsFactory) {
   // If slide mode is enabled, refresh every 5 secs
   var slideModeReset = false;
     $rootScope.$watch('slideMode', function( ) {

--- a/glimpse/js/main.js
+++ b/glimpse/js/main.js
@@ -1,18 +1,7 @@
 var glimpse = angular.module("glimpse", ["ngResource", "ngAnimate", "vAccordion"]);
 
 glimpse.controller("mainCtrl", function ($rootScope, $scope, $window, $timeout, $interval , utils, AtomsFactory) {
-  // If slide mode is enabled, refresh every 5 secs
-  var slideModeReset = false;
-    $rootScope.$watch('slideMode', function( ) {
-      if( !slideModeReset){ slideModeReset = true;}
-      else{
-        $window.alert("SlideMode activated");
-        $interval(AtomsFactory.sampleAtomsInAF, 5000);
-        slideModeReset = true;
-      }
-    });
-
-    // Global vars
+   // Global vars
     var divDockManager, dockManager;
     var toolboxPanel, atomDetailsPanel, terminalPanel, threeDPanel, jsonPanel, planarPanel, schemePanel, tabularPanel,
         filtersPanel, settingsPanel, addNodePanel, connectPanel;

--- a/glimpse/js/main.js
+++ b/glimpse/js/main.js
@@ -2,6 +2,20 @@ var glimpse = angular.module("glimpse", ["ngResource", "ngAnimate", "vAccordion"
 
 glimpse.controller("mainCtrl", function ($rootScope, $scope, $window, $timeout, utils, AtomsFactory) {
 
+  
+  // If slide mode is enabled, refresh every 5 secs
+  var slideModeReset = false;
+  glimpse.controller("mainCtrl", function ($rootScope, $scope, $window, $timeout, 
+      $interval, utils, AtomsFactory) {
+    $rootScope.$watch('slideMode', function( ) {
+      if( !slideModeReset){ slideModeReset = true;}
+      else{
+        $window.alert("SlideMode activated");
+        $interval(AtomsFactory.sampleAtomsInAF, 5000);
+        slideModeReset = true;
+      }
+    });
+
     // Global vars
     var divDockManager, dockManager;
     var toolboxPanel, atomDetailsPanel, terminalPanel, threeDPanel, jsonPanel, planarPanel, schemePanel, tabularPanel,


### PR DESCRIPTION
This is an attempt to solve the cluttering problem when too many atoms are returned from the  GET REST query responses. Currently it randomly samples certain number of atoms returned from the *GET api/v1.1/atoms?filterby=attentionalfocus* response and passes it to the 3d.js visualization algorithm. the random sampling happens every N sec so that it behaves like a slideshow. 