### PR TITLE
Add script for importing Word frequency lists as ConceptNodes

### DIFF
--- a/gtwc/README.md
+++ b/gtwc/README.md
@@ -2,10 +2,10 @@
 
 * Inspired by https://github.com/first20hours/google-10000-english
 
-* The script is used to genrate from [Peter Norvig's](http://norvig.com/ngrams/)
+* The script is used to generate from [Peter Norvig's](http://norvig.com/ngrams/)
   compilation of the [1/3 million most frequent English words](http://norvig.com/ngrams/count_1w.txt),
-  a scheme alist of the frequency.
+  a scheme file containing ConceptNodes with stv calculated from the frequency.
 
-* Run `bash atomize.sh` to get the output file `gtwc-en-333333-words.scm`
+* Run `bash atomize.sh` to get the output file `gtwc-en-333333-words.scm`.
 
 * It takes about 15 seconds to load the ouptut into the atomspace.

--- a/gtwc/README.md
+++ b/gtwc/README.md
@@ -1,0 +1,11 @@
+#### Google's Trillion Word Corpus.(GTWC)
+
+* Inspired by https://github.com/first20hours/google-10000-english
+
+* The script is used to genrate from [Peter Norvig's](http://norvig.com/ngrams/)
+  compilation of the [1/3 million most frequent English words](http://norvig.com/ngrams/count_1w.txt),
+  a scheme alist of the frequency.
+
+* Run `bash atomize.sh` to get the output file `gtwc-en-333333-words.scm`
+
+* It takes about 15 seconds to load the ouptut into the atomspace.

--- a/gtwc/atomize.sh
+++ b/gtwc/atomize.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Input file name
+INPUT_FILE="/tmp/count_1w.txt"
+if [ -f "$INPUT_FILE" ]; then
+    rm "$INPUT_FILE"
+fi
+
+wget -O "$INPUT_FILE" http://norvig.com/ngrams/count_1w.txt
+
+# Output file name
+OUTPUT_FILE="gtwc-en-333333-words.scm"
+
+cat > "$OUTPUT_FILE" << SCM
+(use-modules (opencog))
+
+(define (create-stv count)
+"
+  The total-count used for calculation is sourced from
+  https://research.googleblog.com/2006/08/all-our-n-gram-are-belong-to-you.html
+  as the Norvig extracted the data in count_1w.txt from gtwc.
+"
+    (define total-count 1024908267229.0)
+    (define default-k 800) ; From TruthValue::DEFAULT_K
+    (stv (/ count total-count) (/ count (+ count default-k)))
+)
+
+SCM
+
+# Create the 
+sed 's/\([a-zA-Z0-9]*\)\t\([a-zA-Z0-9]*\)/(Concept "\1" (create-stv \2))/' \
+    "$INPUT_FILE" >> "$OUTPUT_FILE"

--- a/gtwc/atomize.sh
+++ b/gtwc/atomize.sh
@@ -27,6 +27,6 @@ cat > "$OUTPUT_FILE" << SCM
 
 SCM
 
-# Create the 
+# Write the ConceptNodes
 sed 's/\([a-zA-Z0-9]*\)\t\([a-zA-Z0-9]*\)/(Concept "\1" (create-stv \2))/' \
     "$INPUT_FILE" >> "$OUTPUT_FILE"

--- a/gtwc/atomize.sh
+++ b/gtwc/atomize.sh
@@ -11,6 +11,10 @@ wget -O "$INPUT_FILE" http://norvig.com/ngrams/count_1w.txt
 # Output file name
 OUTPUT_FILE="gtwc-en-333333-words.scm"
 
+# TODO:
+# 1. Add creation date of OUTPUT_FILE and the git-sha when creating the
+#    the file.
+# 2. Move to octool.
 cat > "$OUTPUT_FILE" << SCM
 (use-modules (opencog))
 

--- a/nltk_importer/README.md
+++ b/nltk_importer/README.md
@@ -1,0 +1,5 @@
+The [script](import.py) is used to import frequency information of the
+[nltk-corpus](http://www.nltk.org/nltk_data/) into the atomspace. Only a subset of nltk-corpus, that are in
+english, are imported.
+
+See the [script](import.py) for corpora ids used.

--- a/nltk_importer/README.md
+++ b/nltk_importer/README.md
@@ -1,5 +1,6 @@
 The [script](import.py) is used to import frequency information of the
-[nltk-corpus](http://www.nltk.org/nltk_data/) into the atomspace. Only a subset of nltk-corpus, that are in
-english, are imported.
+[nltk-corpus](http://www.nltk.org/nltk_data/) into the atomspace. Only a subset of nltk-corpus, that are in english, are imported.
+
+A bit of cleanup is also perfromed.
 
 See the [script](import.py) for corpora ids used.

--- a/nltk_importer/README.md
+++ b/nltk_importer/README.md
@@ -9,4 +9,4 @@
 
 * Run `python atomize.py` to get the output file `nltk-en.scm`.
 
-* It takes about 19 seconds to load the ouptut into the atomspace.
+* It takes about 20 seconds to load the ouptut into the atomspace.

--- a/nltk_importer/README.md
+++ b/nltk_importer/README.md
@@ -1,6 +1,12 @@
-The [script](import.py) is used to import frequency information of the
-[nltk-corpus](http://www.nltk.org/nltk_data/) into the atomspace. Only a subset of nltk-corpus, that are in english, are imported.
+#### NLTK Corpora importer
 
-A bit of cleanup is also perfromed.
+* The [script](import.py) is used to import frequency information of the
+[nltk-corpus](http://www.nltk.org/nltk_data/) into the atomspace.
 
-See the [script](import.py) for corpora ids used.
+* Only a subset of nltk-corpora, that are in english, are imported.
+
+* See the [script](import.py) for corpora ids used.
+
+* Run `python atomize.py` to get the output file `nltk-en.scm`.
+
+* It takes about 19 seconds to load the ouptut into the atomspace.

--- a/nltk_importer/atomize.py
+++ b/nltk_importer/atomize.py
@@ -44,14 +44,22 @@ print("Finished counting word frequency\n")
 
 # Create the scheme file that has alist of the frequency distribution.
 print("Writing a scheme a-list of the frequency distribution to output.scm")
-with open("output.scm", "w") as scm:
-    output = "(define total-count {})\n".format(freq_dist.N())
-    output += "(define freq-dist (list \n"
-    for word in freq_dist.keys():
-        a_word =  "(cons \"{}\" {})".format(word.encode("utf-8"),
-            freq_dist[word])
-        output += a_word + "\n"
-    output += "\n))"
+output = """
+(use-modules (opencog))
+
+(define (create-stv count)
+    (define total-count {})
+    (define default-k 800) ; From TruthValue::DEFAULT_K
+    (stv (/ count total-count) (/ count (+ count default-k)))
+)
+""".format(freq_dist.N())
+
+for word in freq_dist.keys():
+    a_word =  "(Concept \"{}\" (create-stv {}))".format(word.encode("utf-8"),
+        freq_dist[word])
+    output += a_word + "\n"
+
+with open("nltk-en.scm", "w") as scm:
     scm.write(output)
 
 print("Finished writing to output.scm\n")

--- a/nltk_importer/atomize.py
+++ b/nltk_importer/atomize.py
@@ -43,7 +43,12 @@ freq_dist = nltk.FreqDist(filter(keep_word, word_list))
 print("Finished counting word frequency\n")
 
 # Create the scheme file that has alist of the frequency distribution.
-print("Writing a scheme a-list of the frequency distribution to output.scm")
+print("Writing a scheme a-list of the frequency distribution to nltk-en.scm")
+# TODO:
+# 1. Add creation date of OUTPUT_FILE and the git-sha when creating the
+#    the file.
+# 2. Move to octool.
+
 output = """
 (use-modules (opencog))
 
@@ -62,4 +67,4 @@ for word in freq_dist.keys():
 with open("nltk-en.scm", "w") as scm:
     scm.write(output)
 
-print("Finished writing to output.scm\n")
+print("Finished writing to nltk-en.scm\n")

--- a/nltk_importer/import.py
+++ b/nltk_importer/import.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+import nltk
+
+# English lanugae corpora from the nltk-corpus
+corpora_used = ['abc', 'cmudict', 'comparative_sentences', 'conll2000',
+    'gazetteers', 'genesis', 'gutenberg', 'inaugural', 'masc_tagged',
+    'movie_reviews', 'names', 'opinion_lexicon', 'product_reviews_1',
+    'product_reviews_2', 'pros_cons', 'reuters', 'semcor', 'sentence_polarity',
+    'state_union', 'subjectivity', 'switchboard', 'webtext', 'words']
+
+# List used to collect word lists from the corpora
+word_list = []
+
+# Download the corpora and populate the word_list
+for i in corpora_used:
+    try:
+        nltk.data.find(i)
+        print("Adding {} to word_list.".format(i))
+        word_list += eval("nltk.corpus.{}.words()".format(i))
+        print len(word_list)
+        print("Finished adding {} to word_list.\n".format(i))
+    except LookupError:
+        nltk.download(i)
+        print("Adding {} to word_list.".format(i))
+        word_list += eval("nltk.corpus.{}.words()".format(i))
+        print len(word_list)
+        print("Finished adding {} to word_list.\n".format(i))
+
+# Start counting
+print("Start counting word frequency")
+frequency = nltk.FreqDist(word_list)
+print("Finished counting word frequency")

--- a/nltk_importer/import.py
+++ b/nltk_importer/import.py
@@ -17,16 +17,41 @@ for i in corpora_used:
         nltk.data.find(i)
         print("Adding {} to word_list.".format(i))
         word_list += eval("nltk.corpus.{}.words()".format(i))
-        print len(word_list)
         print("Finished adding {} to word_list.\n".format(i))
     except LookupError:
         nltk.download(i)
         print("Adding {} to word_list.".format(i))
         word_list += eval("nltk.corpus.{}.words()".format(i))
-        print len(word_list)
         print("Finished adding {} to word_list.\n".format(i))
 
-# Start counting
-print("Start counting word frequency")
-frequency = nltk.FreqDist(word_list)
-print("Finished counting word frequency")
+
+def keep_word(word):
+    """
+    If the word has one of the characters specified then return False.
+    """
+    skip_words_with = ["\"", "/", "\\", "*", "+", "=", "[", "]", "(", ")", "{",
+        "}", "<", ">", ",", ";", ":", "|", "#", "@", "%", "$", "^"]
+    for i in skip_words_with:
+        if i in word:
+            return False
+
+    return True
+
+# Clean and start counting
+print("Starting counting word frequency")
+freq_dist = nltk.FreqDist(filter(keep_word, word_list))
+print("Finished counting word frequency\n")
+
+# Create the scheme file that has alist of the frequency distribution.
+print("Writing a scheme a-list of the frequency distribution to output.scm")
+with open("output.scm", "w") as scm:
+    output = "(define total-count {})\n".format(freq_dist.N())
+    output += "(define freq-dist (list \n"
+    for word in freq_dist.keys():
+        a_word =  "(cons \"{}\" {})".format(word.encode("utf-8"),
+            freq_dist[word])
+        output += a_word + "\n"
+    output += "\n))"
+    scm.write(output)
+
+print("Finished writing to output.scm\n")


### PR DESCRIPTION
* Adds scripts for creating ConceptNodes from Nltk corpra, and a fraction of Google's Trillion Word Corpus. 
* ConceptNodes is used instead of list b/c guile isn't able to handle long lists.
* The data created is hosted in https://github.com/opencog/test-datasets
* The data generted is mainly to be used for handling r2l outputs in PLN.
