### PR TITLE
Sumo importer quantifiers

### DIFF
--- a/SUMO_importer/kifparser.py
+++ b/SUMO_importer/kifparser.py
@@ -45,6 +45,7 @@ def skip_comments(myfile):
                or line.startswith('(comment ') \
                or line.startswith('(termFormat ') \
                or line.startswith('(format ') \
+               or line.startswith('(utterance ') \
                or line.startswith('(externalImage '):
                 if '")' in line:
                     line = ""

--- a/SUMO_importer/sumo-opencog.sh
+++ b/SUMO_importer/sumo-opencog.sh
@@ -4,7 +4,7 @@
 # Constants #
 #############
 
-SUMO_TO_ATOM_TYPE_FILE="sumo-to-atom-types.txt"
+ATOM_TYPE_FILE="atom-types.txt"
 
 #############
 # Functions #
@@ -38,17 +38,17 @@ fi
 
 cd "sumo/"
 
-if [ ! -f "$SUMO_TO_ATOM_TYPE_FILE" ]; then
-    info_echo "Infer atom types of SUMO instances, put results in sumo/$SUMO_TO_ATOM_TYPE_FILE"
+if [ ! -f "$ATOM_TYPE_FILE" ]; then
+    info_echo "Infer atom types of SUMO instances, put results in sumo/$ATOM_TYPE_FILE"
     info_echo "Be patient, it may take a while..."
-    ../sumo-to-atom-types.py *.kif >> "$SUMO_TO_ATOM_TYPE_FILE"
+    ../sumo-to-atom-types.py *.kif >> "$ATOM_TYPE_FILE"
 fi
 
 info_echo "Create scheme files"
 
 for file in *.kif; do
     info_echo "Export $file"
-    ../sumo-importer.py "$SUMO_TO_ATOM_TYPE_FILE" $file
+    ../sumo-importer.py "$ATOM_TYPE_FILE" $file
 done
 
 info_echo "Move the generated scheme files to sumo/output"
@@ -61,5 +61,3 @@ mv *.scm output
 cd ..
 
 info_echo "Done"
-
-


### PR DESCRIPTION
Address somewhat the second item of #82. `forall` is converted into `ForAllLink`, `(forall (=>` is converted into `ImplicationScopeLink` `(exist` is converted into `ExistsLink`, etc. For now it aims at being the simplest possible to start experimenting with crisp inferences. The code however has been restructure, is more modular and developer friendly so that changing this conversion rules in the future will be easy.

Other things include wrapping implicit `forall` when necessary, and type the quantifier variables. For now the quantifier variable types are merely the `TypeChoice` of all possible SUMO converted atoms, not ideal, but a lot better than no type at all (cause this tends to throw the pattern matcher in infinite loops, or at best slows it down).