### PR TITLE
HTML Tooltips, plus a few minor features and bug fixes

### DIFF
--- a/AtomSpaceExplorer/README.md
+++ b/AtomSpaceExplorer/README.md
@@ -14,13 +14,14 @@ the REST API, then displayed as a two dimensional graph in the browser.
     - Large: For Node.av.sti >= radiusScaleMinVal  (currently 10).
 - Click on an Atom to view it's properties. Use close icon ('X') to dismiss properties. Or reclick same node to dismiss properties. 
 - Double click on an Atom to filter AtomSpace to that Atom along with two levels of neighboring Atoms.
-- Buttons to Pause / Play / Restart Force Simulation.
-- Buttons to Zoom In, Zoom Out, and Reset Zoom.
+- Buttons to Pause / Play / Restart Force Simulation and  to Zoom In, Zoom Out, and Reset Zoom.
+- Keyboard shortcuts for all of the above buttons are indicated in the corresponding button tooltips.
 - Filtering buttons appear when an Atom is selected or double-clicked (TODO filtering capability needs to be updated).
 - D3 client area and Node context (right-click) menus.
 - Individual Nodes are pinnable into fixed location. Ctrl-click, Ctrl-drag, or right-click Pin (Unpin) a Node. Right-click D3 client area has command to unpin all nodes.
 - D3 client area & SVG canvas dynamically sized relative to browser window size, including auto-resize of Force Simulation. Scrollbars are avoided within of min width, min height or width-to-height ratios.
 - Tooltips for all Navbar and Visualizer command buttons.
+- Node tooltips verbosity is controlled via a toggle checkbox. In verbose mode, the detail level is the same as the selected Node properties table. Both methods can be used together, which provides a convenient way to compare details between a baseline selected Node, and other Nodes via hovering over them.
 - Languages dropdown supports, English, Chinese, French, German, Italian, Japanese and Spanish. Localizations currently implemented for Navbar only.
 
 The AtomSpace Explorer app was based upon the Mozi Visualizer Demo app (which was in turn based on the Glimpse visualizer).
@@ -51,6 +52,15 @@ npm start # will start the visualizer at port 4200
     will be displayed in the graph.
 
 ## Revision History
+### Oct-15-2017 - sshermz - HTML Tooltips, plus a few minor features and bug fixes
+- New Feature: Intelligent HTML formatted tooltips, with normal and verbose modes. Verbose mode is selected via new Tooltips toggle checkbox, which has been added underneath the other D3 graph command buttons. The toggle checkbox is styled to match the Semantic UI teal theme. In Verbose mode, the same level of detail, that's in the right-side Node properties box, is shown. However the tooltips are more convenient for quickly surveying details amongst many Nodes without requiring any clicks. Can also use to compare other Nodes to the selected Node. Default non-verbose tooltips are improved to the same new style, and show both the name if available, like before, but now also always show the type. In other words, now all Nodes show tooltips, dynamically showing what information is available.
+- New Feature: Node properties dialog now also shows Node Name, if there is one.
+- Improvement: Right-justified the Node properties 'X' close icon, as is standard for a close button. Also added circular border to make it's purpose more clear. Also did minor node properties table fixes, cleanups & style refinements.
+- New Feature: Added Esc key handling for cancelling context menus. As a bonus, also added new shortcut keys within the new key handling function for various graph command buttons: Space bar pauses and resumes D3 Force Simulation. Enter restarts D3 Force Simulation. Numpad +/- for Zooming. Numpad * for resetting zoom level. And the graph command button tooltips have been updated to indicate all of these shortcuts to help make them self-evident.
+- Bug Fix: Fixed main context menu which wasn't always available when D3 rect was offset by panning.
+- Bug Fix: Fixed a couple of navbar tooltip positions.
+- Also added some disabled node centering and pan recentering code, but disabled for now as it doesn't work when zoomed in.
+- Minor refactoring.
 ### Oct-10-2017 - sshermz - Initial Commit
 #### *Changes from the Mozi Visualizer Demo app*
 - Changed adjacent link labels to inline, which required adding matching SVG shadow text elements to overwrite link line beneath labels.

--- a/AtomSpaceExplorer/src/app/network/network/network.component.css
+++ b/AtomSpaceExplorer/src/app/network/network/network.component.css
@@ -20,10 +20,6 @@
 	position: absolute;
 }
 
-.ui.icon.buttons {
-  opacity: 0.8;
-}
-
 /*
  * ### D3 Graph related ###
  */
@@ -41,15 +37,45 @@ svg.rect {
 	height: 100%;
 }
 
+.ui.icon.buttons {
+  opacity: 0.8;
+}
+
+/* Tooltips toggle checkbox */
+.ui.toggle.checkbox {
+  opacity: 0.8;
+}
+.ui.toggle.checkbox label {
+  /* font-family: Lato,'Helvetica Neue',Arial,Helvetica,sans-serif; */
+  padding-top: 0em !important;  /* icon alignment */
+}
+.ui.toggle.checkbox input:checked~.box:before, .ui.toggle.checkbox input:checked~label:before {
+  background-color: #00B5AD!important;
+}
+.ui.toggle.checkbox input~.box:before, .ui.toggle.checkbox input~label:before {
+  background-color: #bfece9;
+}
+
+/* Right-side Node properties table */
 .selected-node-properties {
 	position: absolute;
-	right: 0;
+  right: 0;
+  min-width: 180px;
+  max-width: 340px;
   /* background-color: black; */
   background-color: #00B5AD;
 	opacity: 0.7;
-	padding: 10px;
+	padding: 6px;
 	border-top-left-radius: 10px;
 	border-bottom-left-radius: 10px;
+}
+.selected-node-properties table thead tr th i {
+  margin-left: 2em;
+  margin-bottom: 0em;
+}
+/* Right floated not supported by Semantic UI. Manually add support for it */
+.right.floated {
+  float: right;
 }
 
 .links line {
@@ -67,6 +93,101 @@ svg.rect {
 text.edgelabelshadow {
   stroke: #fff;
 }
+
+/* Node tooltips */
+.node-tooltip {
+  position: absolute;
+  text-align: center;
+  line-height: 0.75em !important;
+  padding: 2px;
+  /* font: 10px sans-serif; */
+  font: 12px;
+  background: #00B5AD;
+  pointer-events: none;
+  border-radius: 3px;
+  box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.1);
+}
+.node-detailed-tooltip {
+  position: absolute;
+  text-align: center;
+  padding: 2px;
+  /* font: 10px sans-serif; */
+  font: 12px;
+  background: #00B5AD;
+  pointer-events: none;
+  border-radius: 3px;
+  box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.1);
+}
+
+/* Context (right-click) menus */
+.d3-context-menu {
+	position: absolute;
+	display: none;
+	background-color: #f2f2f2;
+	border-radius: 4px;
+	font-family: Arial, sans-serif;
+	font-size: 14px;
+	min-width: 150px;
+	border: 1px solid #d4d4d4;
+	z-index:1200;
+}
+.d3-context-menu ul {
+	list-style-type: none;
+	margin: 4px 0px;
+	padding: 0px;
+	cursor: default;
+}
+.d3-context-menu ul li {
+	padding: 4px 16px;
+}
+.d3-context-menu ul li:hover {
+	background-color: #4677f8;
+	color: #fefefe;
+}
+
+/*
+.div.tooltip {
+  line-height: 1;
+  font-weight: bold;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  border-radius: 2px;
+}
+
+/* Creates a small triangle extender for the tooltip *
+.div.tooltip:after {
+  box-sizing: border-box;
+  display: inline;
+  font-size: 10px;
+  width: 100%;
+  line-height: 1;
+  color: rgba(0, 0, 0, 0.8);
+  content: "\25BC";
+  position: absolute;
+  text-align: center;
+}
+
+/* Style northward tooltips differently *
+.div.tooltip.n:after {
+  margin: -1px 0 0 0;
+  top: 100%;
+  left: 0;
+}
+*/
+
+/* disable text selection */
+/* svg *::selection {
+  background : transparent;
+}
+
+svg *::-moz-selection {
+  background:transparent;
+}
+
+svg *::-webkit-selection {
+  background:transparent;
+} */
 
 /*
 .source { 

--- a/AtomSpaceExplorer/src/app/network/network/network.component.html
+++ b/AtomSpaceExplorer/src/app/network/network/network.component.html
@@ -4,24 +4,24 @@
     <div class="ui segment visualizer-screen">
       <div class="tools-div">
         <div class="ui icon buttons">
-          <button (click)="play()" class="active ui icon teal button" data-tooltip="Play">
+          <button (click)="play()" class="active ui icon teal button" data-tooltip="Play  (Space bar)" data-position="top left">
             <i class="icon play"></i>
           </button>
-          <button (click)="pause()" class="ui icon teal button" data-tooltip="Pause">
+          <button (click)="pause()" class="ui icon teal button" data-tooltip="Pause  (Space bar)">
           <i class="icon pause"></i>
           </button>
-          <button (click)="restart()" class="ui icon teal button" data-tooltip="Restart">
+          <button (click)="restart()" class="ui icon teal button" data-tooltip="Restart  (Enter)">
             <i class="icon refresh"></i>
           </button>
         </div>
         <div class="ui icon buttons">
-          <button (click)="zoomIn('1000')" class="ui icon teal button" data-tooltip="Zoom in">
+          <button (click)="zoomIn('1000')" class="ui icon teal button" data-tooltip="Zoom in  (Numpad +)">
             <i class="icon plus"></i>
           </button>
-          <button (click)="zoomOut('1000')" class="ui icon teal button" data-tooltip="Zoom out">
+          <button (click)="zoomOut('1000')" class="ui icon teal button" data-tooltip="Zoom out  (Numpad -)">
             <i class="icon minus"></i>
           </button>
-          <button (click)="zoomReset('1000')" class="ui icon teal button" data-tooltip="Reset zoom">
+          <button (click)="zoomReset('1000')" class="ui icon teal button" data-tooltip="Reset zoom  (Numpad *)">
             <i class="icon window restore"></i>
           </button>
         </div>
@@ -51,51 +51,66 @@
             </div>
           </div>
         </div>
+        <br>
+        <div class="ui toggle checkbox" data-tooltip="Detailed tooltips" data-position="bottom left">
+          <input type="checkbox" name="detailedTooltips">
+          <label (click)="toggleTooltips()">
+            <div [ngSwitch]="detailedTooltips">
+              <i *ngSwitchCase="false" class="icon large teal comment outline"></i>
+              <i *ngSwitchCase="true" class="icon large teal talk outline"></i>
+            </div>
+          </label>
+        </div>
       </div>
       <div *ngIf="selectedNode" class="selected-node-properties">
         <table class="ui celled striped table">
           <thead>
             <tr>
-              <th colspan="4">
-                {{ type }}
-                <i (click)="closeSelectedNodeProps()" class="right floated remove icon"></i>
+              <th colspan="2">
+                <span>{{ type }}</span>
+                <i (click) = "closeSelectedNodeProps()" class="ui basic circular right floated remove icon"></i>
+              </th>
+            </tr>
+            <tr *ngIf="name !== ''">
+              <th colspan="2">
+                <span>{{ name }}</span>
               </th>
             </tr>
           </thead>
           <tbody>
             <tr>
               <td class="collapsing">
-                Handle
+                <span>Handle</span>
               </td>
-              <td colspan="2">{{ handle }}</td>
+              <td>{{ handle }}</td>
             </tr>
             <tr>
               <td>
-                LTI
+                <span>LTI</span>
               </td>
               <td>{{ av.lti }}</td>
             </tr>
             <tr>
               <td>
-                STI
+                <span>STI</span>
               </td>
               <td>{{ av.sti }}</td>
             </tr>
             <tr>
               <td>
-                VLTI
+                <span>VLTI</span>
               </td>
               <td>{{ av.vlti }}</td>
             </tr>
             <tr>
               <td>
-                Confidence
+                <span>Confidence</span>
               </td>
               <td>{{ tv.details.confidence }}</td>
             </tr>
             <tr>
               <td>
-                Strength
+                <span>Strength</span>
               </td>
               <td>{{ tv.details.strength }}</td>
             </tr>

--- a/AtomSpaceExplorer/src/app/shared/templates/main-container.component.html
+++ b/AtomSpaceExplorer/src/app/shared/templates/main-container.component.html
@@ -1,13 +1,13 @@
 <div class="ui attached stackable menu">
   <div class="item">
-    <span data-tooltip="The OpenCog Foundation" data-position="right center">
+    <span data-tooltip="The OpenCog Foundation" data-position="bottom left">
       <a href="http://opencog.org/" target="_blank" class="ui mini image">
         <img src="../../../assets/img/Logo.png" alt="OpenCog">
       </a>
     </span>
   </div>
   <a class="item" routerLink="">
-    <span data-tooltip="Fetch data from AtomSpace Service" data-position="bottom center">
+    <span data-tooltip="Fetch data from AtomSpace Service" data-position="bottom left">
       <i class="icon large cloud download"></i> {{ 'Fetch' | translate }}
     </span>
   </a>


### PR DESCRIPTION
- New Feature: Intelligent HTML formatted tooltips, with normal and verbose modes. Verbose mode is selected via new Tooltips toggle checkbox, which has been added underneath the other D3 graph command buttons. The toggle checkbox is styled to match the Semantic UI teal theme. In Verbose mode, the same level of detail, that's in the right-side Node properties box, is shown. However the tooltips are more convenient for quickly surveying details amongst many Nodes without requiring any clicks. Can also use to compare other Nodes to the selected Node. Default non-verbose tooltips are improved to the same new style, and show both the name if available, like before, but now also always show the type. In other words, now all Nodes show tooltips, dynamically showing what information is available.
- New Feature: Node properties dialog now also shows Node Name, if there is one.
- Improvement: Right-justified the Node properties 'X' close icon, as is standard for a close button. Also added circular border to make it's purpose more clear. Also did minor node properties table fixes, cleanups & style refinements.
- New Feature: Added Esc key handling for cancelling context menus. As a bonus, also added new shortcut keys within the new key handling function for various graph command buttons: Space bar pauses and resumes D3 Force Simulation. Enter restarts D3 Force Simulation. Numpad +/- for Zooming. Numpad * for resetting zoom level. And the graph command button tooltips have been updated to indicate all of these shortcuts to help make them self-evident.
- Bug Fix: Fixed main context menu which wasn't always available when D3 rect was offset by panning.
- Bug Fix: Fixed a couple of navbar tooltip positions.
- Also added some disabled node centering and pan recentering code, but disabled for now as it doesn't work when zoomed in.
- Minor refactoring.