### PR TITLE
Simulation Force update and bug fixes.

### DIFF
--- a/AtomSpaceExplorer/README.md
+++ b/AtomSpaceExplorer/README.md
@@ -51,9 +51,9 @@ npm start -- --port=8080            # Example with port number 8080.
 
 Alternatively, you can permanently change the default port by inserting the following to angular-cli.json, at the top of the "defaults" block:
   "defaults": {                     #    Existing line.
-    "serve": {                      # <- Inserted line.
-      "port": 8080                  # <- Inserted line. Example port 8080. Set port number as desired.
-    },                              # <- Inserted line.
+    "serve": {                      # <- Insert line.
+      "port": 8080                  # <- Insert line. Example port 8080. Set port number as desired.
+    },                              # <- Insert line.
     "styleExt": "css",              #    Existing line.
 
 ```
@@ -62,9 +62,9 @@ Alternatively, you can permanently change the default port by inserting the foll
 
 1 - Navigate to [http://localhost:4200/](http://localhost:4200/)
 
-2 - Click on Fetch. A 'Fetch Results From AtomSpace' prompt is displayed. Enter a valid AtomSpace api url.
+2 - Click on Fetch. A 'Fetch AtomSpace Results' prompt is displayed. Enter a valid AtomSpace api url.
     I.E <http://255.255.255.255:5000/api/v1.1/atoms>, then click on the Fetch button to graph the data. 
-    Alternatively, click on 'Load Sample Data', to load the built-in sample data file ./src/assets/atoms.json.
+    Alternatively, click on 'Load Sample Data', to load the built-in sample data file. See next section regarding sample data.
 
 ## Sample Data
 
@@ -77,6 +77,7 @@ Alternatively, you can permanently change the default port by inserting the foll
   - atoms.sample2.json: Original external sample.
   - atoms.humans.json: From humans.scm.
   - atoms.oovc\_ensemble.json: From oovc_ensemble.scm.
+  - atoms.oovc\_ensemble\_sti.json: Same as previous, with non-zero STI values. <== *Configured as default sample*
 
 ## Known Issues
 
@@ -86,6 +87,15 @@ Alternatively, you can permanently change the default port by inserting the foll
 - Languages support is minimal and needs to be implemented throughout the UI.
 
 ## Revision History
+
+### Nov-27-2017 - sshermz - Simulation Force update and bug fixes
+
+- Feature Change: Revised Simulation Force to avoid squashing of Atoms/Links to the D3 client area boundaries (includes removal of gravity force from previous commit which only helped in certain cases). Fixes #105.
+- Samples: Added another sample json file, atoms.oovc\_ensemble\_sti.json, and changed to it as the default built-in sample.
+- Bug Fix: Suppress tooltips after Fetch until mouse is moved one time. Avoids unintended tooltips when Fetch data and Nodes or Links happen to slide under mouse cursor.
+- Bug Fix: Fixed stroke width bug in Node decorator drawing code.
+- Bug Fix: Fixed context menu regression.
+- Refactoring: More refactoring of the D3 graphing code.
 
 ### Nov-24-2017 - sshermz - Tooltips for Links, auto-positioning tooltips, Simulation Force tweaks, package updates, etc
 

--- a/AtomSpaceExplorer/package-lock.json
+++ b/AtomSpaceExplorer/package-lock.json
@@ -2840,11 +2840,6 @@
         "d3-timer": "1.0.7"
       }
     },
-    "d3-force-gravity": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/d3-force-gravity/-/d3-force-gravity-1.0.2.tgz",
-      "integrity": "sha1-1bbrvKXZdHYNJW+wNAXBbiAvnn8="
-    },
     "d3-format": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.0.tgz",

--- a/AtomSpaceExplorer/package.json
+++ b/AtomSpaceExplorer/package.json
@@ -29,7 +29,6 @@
     "core-js": "^2.5.1",
     "d3": "^4.11.0",
     "d3-context-menu": "^0.1.2",
-    "d3-force-gravity": "^1.0.2",
     "hammerjs": "^2.0.8",
     "jquery": "^3.2.1",
     "lodash": "^4.17.4",

--- a/AtomSpaceExplorer/src/app/app.config.ts
+++ b/AtomSpaceExplorer/src/app/app.config.ts
@@ -2,5 +2,6 @@ export const configs = {
   'url': 'http://localhost:7070/api/',
   'opencog_url': 'http://localhost:5000/api/v1.1',
   'opencog_url_timeout': '10000',
-  'sample_data_file': 'atoms.sample1b.json'
+  // 'sample_data_file': 'atoms.sample1b.json'
+  'sample_data_file': 'atoms.oovc_ensemble_sti.json'
 };

--- a/AtomSpaceExplorer/src/app/network/network/network.component.html
+++ b/AtomSpaceExplorer/src/app/network/network/network.component.html
@@ -66,6 +66,9 @@
             <div class="item" (click)="filterByNode('MemberLink')">
               <span>MemberLink</span>
             </div>
+            <div class="item" (click)="filterByNode('OrLink')">
+              <span>OrLink</span>
+            </div>
             <div class="item" (click)="filterByNode('ReferenceLink')">
               <span>ReferenceLink</span>
             </div>

--- a/AtomSpaceExplorer/src/assets/atoms.oovc_ensemble_sti.json
+++ b/AtomSpaceExplorer/src/assets/atoms.oovc_ensemble_sti.json
@@ -1,0 +1,2193 @@
+{
+  "result": {
+    "atoms": [{
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 4,
+      "incoming": [3],
+      "name": "",
+      "outgoing": [1, 2],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 7,
+      "incoming": [3],
+      "name": "",
+      "outgoing": [5, 6],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 10,
+      "incoming": [9],
+      "name": "",
+      "outgoing": [8, 6],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 13,
+      "incoming": [11, 12],
+      "name": "",
+      "outgoing": [2, 8],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 17,
+      "incoming": [11],
+      "name": "",
+      "outgoing": [14, 15, 5, 16],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 21,
+      "incoming": [20],
+      "name": "",
+      "outgoing": [18, 19],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 24,
+      "incoming": [23],
+      "name": "",
+      "outgoing": [22, 19],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 25,
+      "incoming": [12],
+      "name": "",
+      "outgoing": [15, 5, 16],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 30,
+      "incoming": [28, 29],
+      "name": "",
+      "outgoing": [26, 27],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 35,
+      "incoming": [33, 34, 29],
+      "name": "",
+      "outgoing": [31, 32],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 38,
+      "incoming": [37],
+      "name": "",
+      "outgoing": [19, 36],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 41,
+      "incoming": [40],
+      "name": "",
+      "outgoing": [34, 39],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 45,
+      "incoming": [44],
+      "name": "",
+      "outgoing": [42, 43],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 48,
+      "incoming": [42],
+      "name": "",
+      "outgoing": [46, 47],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 49,
+      "incoming": [33],
+      "name": "",
+      "outgoing": [27, 39],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 52,
+      "incoming": [51],
+      "name": "",
+      "outgoing": [50, 46],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 55,
+      "incoming": [54],
+      "name": "",
+      "outgoing": [19, 53],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 58,
+      "incoming": [51],
+      "name": "",
+      "outgoing": [56, 57],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 60,
+      "incoming": [59],
+      "name": "",
+      "outgoing": [42, 51],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 63,
+      "incoming": [62],
+      "name": "",
+      "outgoing": [61, 42],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 65,
+      "incoming": [28],
+      "name": "",
+      "outgoing": [31, 64, 32],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 68,
+      "incoming": [67],
+      "name": "",
+      "outgoing": [66, 42],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "AndLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 6,
+      "incoming": [10, 7],
+      "name": "",
+      "outgoing": [2, 16],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 8,
+      "incoming": [10, 13],
+      "name": "",
+      "outgoing": [1, 5],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 36,
+      "incoming": [38],
+      "name": "",
+      "outgoing": [69, 70, 71, 72],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 18,
+      "incoming": [21],
+      "name": "",
+      "outgoing": [69, 73, 71],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 53,
+      "incoming": [55],
+      "name": "",
+      "outgoing": [69, 74, 71],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 22,
+      "incoming": [24],
+      "name": "",
+      "outgoing": [69, 75, 71],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 43,
+      "incoming": [45],
+      "name": "",
+      "outgoing": [50, 57, 76, 77, 78, 79],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 64,
+      "incoming": [65],
+      "name": "",
+      "outgoing": [80, 81],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 19,
+      "incoming": [24, 55, 21, 38],
+      "name": "",
+      "outgoing": [82, 83],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 66,
+      "incoming": [68],
+      "name": "",
+      "outgoing": [50, 57, 76, 77],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 11,
+      "incoming": [84],
+      "name": "",
+      "outgoing": [13, 17],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 28,
+      "incoming": [85],
+      "name": "",
+      "outgoing": [65, 30],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 29,
+      "incoming": [86],
+      "name": "",
+      "outgoing": [35, 30],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 3,
+      "incoming": [87],
+      "name": "",
+      "outgoing": [7, 4],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 12,
+      "incoming": [88],
+      "name": "",
+      "outgoing": [13, 25],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 34,
+      "incoming": [41],
+      "name": "",
+      "outgoing": [27, 35],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 51,
+      "incoming": [60],
+      "name": "",
+      "outgoing": [76, 52, 78, 58],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 33,
+      "incoming": [89],
+      "name": "",
+      "outgoing": [35, 49],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 39,
+      "incoming": [49, 41],
+      "name": "",
+      "outgoing": [26, 32],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 42,
+      "incoming": [63, 68, 60, 45],
+      "name": "",
+      "outgoing": [90, 48],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 61,
+      "incoming": [63],
+      "name": "",
+      "outgoing": [50, 57, 76, 77, 79],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "OrLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 16,
+      "incoming": [17, 25, 6],
+      "name": "",
+      "outgoing": [1],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 5,
+      "incoming": [17, 7, 25, 8],
+      "name": "",
+      "outgoing": [91],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 15,
+      "incoming": [17, 25],
+      "name": "",
+      "outgoing": [92],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 70,
+      "incoming": [36],
+      "name": "",
+      "outgoing": [93],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 71,
+      "incoming": [22, 53, 18, 36],
+      "name": "",
+      "outgoing": [94],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 83,
+      "incoming": [19],
+      "name": "",
+      "outgoing": [73],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 2,
+      "incoming": [4, 13, 6],
+      "name": "",
+      "outgoing": [14],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 32,
+      "incoming": [35, 65, 39],
+      "name": "",
+      "outgoing": [95],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 47,
+      "incoming": [48],
+      "name": "",
+      "outgoing": [76],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 82,
+      "incoming": [19],
+      "name": "",
+      "outgoing": [69],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 27,
+      "incoming": [49, 30, 34],
+      "name": "",
+      "outgoing": [80],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 81,
+      "incoming": [64],
+      "name": "",
+      "outgoing": [96],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 31,
+      "incoming": [35, 65],
+      "name": "",
+      "outgoing": [26],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 78,
+      "incoming": [51, 43],
+      "name": "",
+      "outgoing": [97],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 46,
+      "incoming": [48, 52],
+      "name": "",
+      "outgoing": [57],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 72,
+      "incoming": [36],
+      "name": "",
+      "outgoing": [98],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 90,
+      "incoming": [42],
+      "name": "",
+      "outgoing": [50],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 79,
+      "incoming": [43, 61],
+      "name": "",
+      "outgoing": [99],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 77,
+      "incoming": [66, 43, 61],
+      "name": "",
+      "outgoing": [56],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "NotLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 9,
+      "incoming": [],
+      "name": "",
+      "outgoing": [100, 10],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 37,
+      "incoming": [],
+      "name": "",
+      "outgoing": [101, 38],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 20,
+      "incoming": [],
+      "name": "",
+      "outgoing": [102, 21],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 59,
+      "incoming": [],
+      "name": "",
+      "outgoing": [103, 60],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 85,
+      "incoming": [],
+      "name": "",
+      "outgoing": [104, 28],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 54,
+      "incoming": [],
+      "name": "",
+      "outgoing": [105, 55],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 40,
+      "incoming": [],
+      "name": "",
+      "outgoing": [106, 41],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 89,
+      "incoming": [],
+      "name": "",
+      "outgoing": [107, 33],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 87,
+      "incoming": [],
+      "name": "",
+      "outgoing": [108, 3],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 62,
+      "incoming": [],
+      "name": "",
+      "outgoing": [109, 63],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 84,
+      "incoming": [],
+      "name": "",
+      "outgoing": [110, 11],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 67,
+      "incoming": [],
+      "name": "",
+      "outgoing": [111, 68],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 88,
+      "incoming": [],
+      "name": "",
+      "outgoing": [112, 12],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 86,
+      "incoming": [],
+      "name": "",
+      "outgoing": [113, 29],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 44,
+      "incoming": [],
+      "name": "",
+      "outgoing": [114, 45],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 23,
+      "incoming": [],
+      "name": "",
+      "outgoing": [115, 24],
+      "truthvalue": {
+        "details": {
+          "confidence": 1,
+          "count": 3999999199.8849773,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "EquivalenceLink"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 1,
+        "vlti": false
+      },
+      "handle": 108,
+      "incoming": [87],
+      "name": "oovc_ensemble:moses_model_15",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 4,
+        "vlti": false
+      },
+      "handle": 110,
+      "incoming": [84],
+      "name": "oovc_ensemble:moses_model_14",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 28,
+        "vlti": false
+      },
+      "handle": 14,
+      "incoming": [17, 2],
+      "name": "CHD7",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 15,
+        "vlti": false
+      },
+      "handle": 1,
+      "incoming": [4, 8, 16],
+      "name": "FLJ40536",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 20,
+        "vlti": false
+      },
+      "handle": 91,
+      "incoming": [5],
+      "name": "FKBP11",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 2,
+        "vlti": false
+      },
+      "handle": 92,
+      "incoming": [15],
+      "name": "SPINT1",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 17,
+        "vlti": false
+      },
+      "handle": 93,
+      "incoming": [70],
+      "name": "RXFP3",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 1,
+        "vlti": false
+      },
+      "handle": 98,
+      "incoming": [72],
+      "name": "STK39",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 7,
+        "vlti": false
+      },
+      "handle": 74,
+      "incoming": [53],
+      "name": "TRAF1",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 26,
+        "vlti": false
+      },
+      "handle": 94,
+      "incoming": [71],
+      "name": "PDZD9",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 3,
+        "vlti": false
+      },
+      "handle": 103,
+      "incoming": [59],
+      "name": "oovc_ensemble:moses_model_04",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 17,
+        "vlti": false
+      },
+      "handle": 107,
+      "incoming": [89],
+      "name": "oovc_ensemble:moses_model_03",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 9,
+        "vlti": false
+      },
+      "handle": 57,
+      "incoming": [58, 66, 43, 61, 46],
+      "name": "SLC16A5",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 21,
+        "vlti": false
+      },
+      "handle": 106,
+      "incoming": [40],
+      "name": "oovc_ensemble:moses_model_02",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 17,
+        "vlti": false
+      },
+      "handle": 50,
+      "incoming": [52, 66, 43, 61, 90],
+      "name": "FREM3",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 19,
+        "vlti": false
+      },
+      "handle": 100,
+      "incoming": [9],
+      "name": "oovc_ensemble:moses_model_13",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 25,
+        "vlti": false
+      },
+      "handle": 26,
+      "incoming": [30, 39, 31],
+      "name": "KCNJ15",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 8,
+        "vlti": false
+      },
+      "handle": 69,
+      "incoming": [22, 53, 18, 36, 82],
+      "name": "LINC00692",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 16,
+        "vlti": false
+      },
+      "handle": 75,
+      "incoming": [22],
+      "name": "MRPS26",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 14,
+        "vlti": false
+      },
+      "handle": 105,
+      "incoming": [54],
+      "name": "oovc_ensemble:moses_model_09",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 96,
+      "incoming": [81],
+      "name": "TBC1D21",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 18,
+        "vlti": false
+      },
+      "handle": 111,
+      "incoming": [67],
+      "name": "oovc_ensemble:moses_model_05",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 21,
+        "vlti": false
+      },
+      "handle": 101,
+      "incoming": [37],
+      "name": "oovc_ensemble:moses_model_11",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 16,
+        "vlti": false
+      },
+      "handle": 80,
+      "incoming": [64, 27],
+      "name": "CRISPLD1",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 26,
+        "vlti": false
+      },
+      "handle": 113,
+      "incoming": [86],
+      "name": "oovc_ensemble:moses_model_01",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 9,
+        "vlti": false
+      },
+      "handle": 112,
+      "incoming": [88],
+      "name": "oovc_ensemble:moses_model_12",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 16,
+        "vlti": false
+      },
+      "handle": 104,
+      "incoming": [85],
+      "name": "oovc_ensemble:moses_model_00",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 28,
+        "vlti": false
+      },
+      "handle": 95,
+      "incoming": [32],
+      "name": "TRIM5",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 13,
+        "vlti": false
+      },
+      "handle": 56,
+      "incoming": [58, 77],
+      "name": "DCAF8",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 14,
+        "vlti": false
+      },
+      "handle": 102,
+      "incoming": [20],
+      "name": "oovc_ensemble:moses_model_10",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 12,
+        "vlti": false
+      },
+      "handle": 97,
+      "incoming": [78],
+      "name": "CUX1",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 3,
+        "vlti": false
+      },
+      "handle": 109,
+      "incoming": [62],
+      "name": "oovc_ensemble:moses_model_06",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 16,
+        "vlti": false
+      },
+      "handle": 114,
+      "incoming": [44],
+      "name": "oovc_ensemble:moses_model_07",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 29,
+        "vlti": false
+      },
+      "handle": 99,
+      "incoming": [79],
+      "name": "C1orf146",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 5,
+        "vlti": false
+      },
+      "handle": 115,
+      "incoming": [23],
+      "name": "oovc_ensemble:moses_model_08",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 0,
+        "vlti": false
+      },
+      "handle": 76,
+      "incoming": [66, 51, 43, 61, 47],
+      "name": "TPGS1",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }, {
+      "attentionvalue": {
+        "lti": 0,
+        "sti": 8,
+        "vlti": false
+      },
+      "handle": 73,
+      "incoming": [18, 83],
+      "name": "PCBP4",
+      "outgoing": [],
+      "truthvalue": {
+        "details": {
+          "confidence": 0,
+          "count": 0,
+          "strength": 1
+        },
+        "type": "simple"
+      },
+      "type": "PredicateNode"
+    }],
+    "complete": true,
+    "skipped": 0,
+    "total": 115
+  }
+}


### PR DESCRIPTION
Simulation Force update and bug fixes.

- Feature Change: Revised Simulation Force to avoid squashing of Nodes / Links to the D3 client area boundaries (includes removal of gravity force from previous commit which only helped in certain cases). Fixes #105.
- Samples: Added another sample json file, atoms.oovc\_ensemble\_sti.json, and changed to it as the default built-in sample.
- Bug Fix: Suppress tooltips after Fetch until mouse is moved one time. Avoids unintended tooltips when Fetch data and Nodes or Links happen to slide under mouse cursor.
- Bug Fix: Fixed stroke width bug in Node decorator drawing code.
- Bug Fix: Fixed context menu regression.
- Refactoring: More refactoring of the D3 graphing code.
