### PR TITLE
Bug fix and multiple link handling improvement

### DIFF
--- a/AtomSpaceExplorer/README.md
+++ b/AtomSpaceExplorer/README.md
@@ -87,6 +87,11 @@ Alternatively, you can permanently change the default port by inserting the foll
 
 ## Revision History
 
+### Jan-3-2018 - sshermz - Bug fix and multiple link handling improvement
+
+- Bug Fix: Double-click on nodes to drill didn't work in the region covered by the selected node properties table, even when the table was hidden. Bonus with this fix is that you can now drag nodes even if they are behind the visible selected node properties table.
+- Feature Change: Max number of multiple links supported increased from 3 maximum to 7 maximum. Beyond 7 will need to be handled in a different manner in the future.
+
 ### Jan-2-2018 - sshermz - Link enhancements: Directional arrowheads and support for multiple links between nodes. Also bug fixes
 
 - New Feature: Added arrowheads to link lines. Ordered (assymmetric) link types now have a single arrowhead to show "incoming set" direction. And unordered (symmetric) link types now have arrowheads on both ends. For now, unordered link types are identified by new config parameter 'unordered\_linktype\_roots' in app.config.ts. Fixes #108.

--- a/AtomSpaceExplorer/src/app/network/network/network.component.css
+++ b/AtomSpaceExplorer/src/app/network/network/network.component.css
@@ -73,14 +73,18 @@ svg.rect {
 	opacity: 0.9;
 	padding: 6px;
 	border-top-left-radius: 10px;
-	border-bottom-left-radius: 10px;
+  border-bottom-left-radius: 10px;
+  user-select: none;
+  pointer-events: none;  /* Allow selecting, dragging, etc through the table... */
+}
+#selected-node-properties-close-btn {
+  pointer-events: all;  /* ...However, need to enable pointer-events on close button */
 }
 .selected-node-properties table thead tr th i {
   margin-left: 2em;
   margin-bottom: 0em;
 }
-/* Right floated not supported by Semantic UI. Manually add support for it */
-.right.floated {
+.right.floated {  /* Right floated not supported by Semantic UI. Manually add support for it */
   float: right;
 }
 

--- a/AtomSpaceExplorer/src/app/network/network/network.component.html
+++ b/AtomSpaceExplorer/src/app/network/network/network.component.html
@@ -53,12 +53,12 @@
           </div>
         </div>
         <div *ngIf="isSelectedNode" class="selected-node-properties">
-          <table class="ui celled striped table" style="user-select: none">
+          <table class="ui celled striped table">
             <thead>
               <tr>
                 <th colspan="2">
                   <span>{{ selectedNodeData.type }}</span>
-                  <i (click)="closeSelectedNodeProps()" class="ui basic circular right floated remove icon"></i>
+                  <i (click)="closeSelectedNodeProps()" class="ui basic circular right floated remove icon" id="selected-node-properties-close-btn"></i>
                 </th>
               </tr>
               <tr *ngIf="name !== ''">


### PR DESCRIPTION
- Bug Fix: Double-click on nodes to drill didn't work in the region covered by the selected node properties table, even when the table was hidden. Bonus with this fix is that you can now drag nodes even if they are behind the visible selected node properties table.
- Feature Change: Max number of multiple links supported increased from 3 maximum to 7 maximum. Beyond 7 will need to be handled in a different manner in the future.